### PR TITLE
fix:#51 Prevent duplicating reminders

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -51,3 +51,17 @@ class testReminders(TestCase):
         resp_json = json.loads(response.content)
         self.assertEqual(Alert.objects.all().count(), 0)
         self.assertEqual(resp_json['status'], '410 Gone')
+   
+
+    def testPreventDuplicateReminder(self):
+        arraignment_datetime = (datetime.today() + timedelta(days=8)).strftime('%Y-%m-%dT%H:%M:%S')
+        request = self._post('/api/reminders', {
+            "arraignment_datetime": arraignment_datetime,
+            "case_num": 1,
+            "phone_num": "+1-918-555-5555",
+        })       
+        response = reminders(request)
+        reminders(request) # Submitting a duplicate reminder
+        resp_json = json.loads(response.content)
+        self.assertEqual(Alert.objects.all().count(), 2)
+        self.assertEqual(resp_json['status'], '201 Created')

--- a/api/tests.py
+++ b/api/tests.py
@@ -61,7 +61,9 @@ class testReminders(TestCase):
             "phone_num": "+1-918-555-5555",
         })       
         response = reminders(request)
-        reminders(request) # Submitting a duplicate reminder
         resp_json = json.loads(response.content)
+        self.assertEqual(Alert.objects.all().count(), 2)
+        self.assertEqual(resp_json['status'], '201 Created')
+        reminders(request) # Submitting a duplicate reminder
         self.assertEqual(Alert.objects.all().count(), 2)
         self.assertEqual(resp_json['status'], '201 Created')

--- a/api/views.py
+++ b/api/views.py
@@ -63,14 +63,14 @@ def reminders(request):
         "status":"201 Created"
     }
     if week_alert_datetime > datetime.today():
-        Alert.objects.create(
+        Alert.objects.get_or_create(
             when=week_alert_datetime,
             what=f'Arraignment for case {case_num} in 1 week at {arraignment_datetime}',
             to=phone_num
         )
         message['week_before_datetime'] = week_alert_datetime
     if day_alert_datetime > datetime.today():
-        Alert.objects.create(
+        Alert.objects.get_or_create(
             when=day_alert_datetime,
             what=f'Arraignment for case {case_num} in 1 day at {arraignment_datetime}',
             to=phone_num


### PR DESCRIPTION
Use `get_or_create` instead of `create` to prevent duplicating reminders + test