### PR TITLE
Issue #61 Form add

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -138,6 +138,22 @@ footer a:hover {
 	color: #333;
 }
 
+#case-form {
+	max-width: 500px;
+	margin-right: auto;
+	margin-left: auto;
+}
+
+.form-group {
+	position: relative;
+}
+
+#small {
+	position: absolute;
+	left: 5px;
+	margin-bottom: 10px;
+}
+
 /* Tablet Breakpoint */
 @media all and (min-width: 768px) {
 	.display-1, h1 {

--- a/website/templates/base_generic.html
+++ b/website/templates/base_generic.html
@@ -9,10 +9,13 @@
 		<meta name="author" content="Code for Tulsa">
 
 		<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
+		<script src="https://unpkg.com/jquery"></script>
+		<script src="https://unpkg.com/bootstrap"></script>
 		<link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet">
 		<!-- Add additional CSS in static file -->
 		{% load static %}
-		<link rel="stylesheet" href="{% static "css/styles.css" %}">
+		<!-- <link rel="stylesheet" href="{% static "css/styles.css" %}"> -->
+		<link rel="stylesheet" href="static/css/styles.css">
 
 		<!-- Global site tag (gtag.js) - Google Analytics -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-132409583-1"></script>

--- a/website/templates/base_generic.html
+++ b/website/templates/base_generic.html
@@ -15,7 +15,7 @@
 		<!-- Add additional CSS in static file -->
 		{% load static %}
 		<!-- <link rel="stylesheet" href="{% static "css/styles.css" %}"> -->
-		<link rel="stylesheet" href="static/css/styles.css">
+		<link rel="stylesheet" href="/static/css/styles.css">
 
 		<!-- Global site tag (gtag.js) - Google Analytics -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-132409583-1"></script>

--- a/website/templates/base_generic.html
+++ b/website/templates/base_generic.html
@@ -14,8 +14,7 @@
 		<link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet">
 		<!-- Add additional CSS in static file -->
 		{% load static %}
-		<!-- <link rel="stylesheet" href="{% static "css/styles.css" %}"> -->
-		<link rel="stylesheet" href="/static/css/styles.css">
+		<link rel="stylesheet" href="{% static "css/styles.css" %}">
 
 		<!-- Global site tag (gtag.js) - Google Analytics -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-132409583-1"></script>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -4,6 +4,11 @@
 
 <div class="jumbotron bright-yellow-bkg">
 	<div class="container text-center">
+		{% if messages %}
+        	{% for message in messages %}
+    		<p{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</p>
+    		{% endfor %}
+		{% endif %}
 		<h1 class="display-1">Get Court Date Reminders</h1>
 		<p class="display-2">Text your OSCN Case&nbsp;Number:</p>
 		<div class="row justify-content-center">
@@ -28,6 +33,28 @@
 			<!-- <div class="col-sm-4 display-3">Rogers <br />County<br /><a class="btn btn-lg btn-yellow" style="font-size:20px" href="sms:9182059352">(918)-205-9352</a></div> -->
 			<!-- <div class="col-sm-4 display-3">Tulsa <br />County<br /><a class="btn btn-lg btn-yellow" style="font-size:20px" href="sms:9189923222">(918)-992-3222</a></div> -->
 		</div>
+		<p class="display-3">Or Fill Out Form:</p>
+		<form action="/form_data" id="case-form" method="POST">
+			<div class="form-group">
+				<input type="text" class="form-control" id="case_num" name="case_num" placeholder="Enter case number">
+			</div>
+			<div class="form-group">	
+				<input type="number" class="form-control" id="year" name="year" min="2000" max="2100" placeholder="Enter year filed">
+			</div>
+			<div class="form-group">
+				<input type="text" class="form-control" id="county" name="county" placeholder="Enter county">
+			</div>
+			<div class="form-group">
+				<input type="tel" class="form-control" id="phone_num" name="phone_num" placeholder="Reminder Phone Number"
+				pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}">
+				<small id="small">ex: 918-123-4567</small>
+			</div>
+			<div class="form-group">
+				<input type="tel" class="form-control" id="add_phone_num" name="add_phone_num" placeholder="Additional Phone Number"
+				pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}">
+			</div>
+			<button type="submit" class="btn btn-primary">Submit</button>
+		</form>
 
 	</div>
 </div>
@@ -72,7 +99,7 @@
 			</div>
 			<div class="col-sm-6">
 				<h4>2. What if I still can't find my case number?</h4>
-				<p>Check with your public defender or search your name online at <a href=“www.oscn.net/docets/search.aspx”>www.oscn.net/docets/search.aspx </a> </p> </div> <div class="col-sm-6">
+				<p>Check with your public defender or search your name online at <a href=“www.oscn.net/dockets/search.aspx”>www.oscn.net/docets/search.aspx </a> </p> </div> <div class="col-sm-6">
 						<h4>3. Can other people be reminded of my court date?</h4>
 						<p>Anyone with your case number will be able to use courtbot to keep track of your court date.</p>
 			</div>

--- a/website/tests.py
+++ b/website/tests.py
@@ -1,3 +1,48 @@
-from django.test import TestCase
-
 # Create your tests here.
+from django.test import TestCase, RequestFactory, Client
+import json
+
+class testFormViews(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.client = Client()
+
+    def test_form_data_view_passed(self):
+        data = {
+                "case_num": "CF-2020-1648",
+                "year": 2020,
+                "county": "Tulsa",
+                "phone_num": 918-555-5555,
+                "add_phone_num": 918-111-1111
+        }
+        resp = self.client.post("https://courtbot-python.herokuapp.com/form_data", data=data, follow=True)
+       
+        self.assertIn(str.encode("Arraignment for case CF-2020-1648 has already passed"), resp.content)
+    
+    def test_form_data_view_not_found(self):
+        data = {
+                "case_num": "1000000000",
+                "year": 2020,
+                "county": "Tulsa",
+                "phone_num": 918-555-5555,
+                "add_phone_num": 918-111-1111
+        }
+        resp = self.client.post("https://courtbot-python.herokuapp.com/form_data", data=data, follow=True)
+     
+        self.assertIn(str.encode("Unable to find arraignment event with the following year 2020, county Tulsa, case number 1000000000"), resp.content)
+    
+    def test_form_data_view_scheduled(self):
+        data = {
+                "case_num": "CF-2020-2803",
+                "year": 2020,
+                "county": "Tulsa",
+                "phone_num": 918-555-5555,
+                "add_phone_num": 918-111-1111
+        }
+        resp = self.client.post("https://courtbot-python.herokuapp.com/form_data", data=data, follow=True)
+     
+        self.assertIn(str.encode("Reminder scheduled"), resp.content)
+
+            
+       

--- a/website/urls.py
+++ b/website/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('form_data', views.form_data, name='form_data')
 ]

--- a/website/views.py
+++ b/website/views.py
@@ -1,7 +1,59 @@
+from django.shortcuts import render, redirect
+from datetime import datetime, timedelta
+import re
+
+from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render
+from django.views.decorators.csrf import csrf_exempt
+from django.contrib import messages
+
+import oscn, requests, json
+
+
+from alerts.models import Alert
 
 def index(request):
     # """View function for home page of site."""
 
     # Render the HTML template index.html with the data in the context variable
     return render(request, 'index.html')
+
+@csrf_exempt
+def form_data(request):
+    # Processes form data, requests arraignment data from api/case, and posts reminder data to api/reminder
+    # Includes option for extra phone number for additional recipient
+    case_num = request.POST['case_num']
+    year = request.POST['year']
+    county = request.POST['county']
+    phone_num = request.POST['phone_num']
+    add_num = request.POST['add_phone_num']
+    response = requests.get(
+        f"https://courtbot-python.herokuapp.com/api/case?year={year}&county={county}&case_num={case_num}"
+    )
+    resp_json = json.loads(response.content)
+
+    if resp_json.get('error', None):
+        message = resp_json['error']
+        messages.error(request, message)
+    else:
+        arraignment_datetime = resp_json.get('arraignment_datetime', None)
+        reminder_request = requests.post('https://courtbot-python.herokuapp.com/api/reminders', {
+            "arraignment_datetime": arraignment_datetime,
+            "case_num": case_num,
+            "phone_num": f"+1-{phone_num}"
+        })
+        resp_json = json.loads(reminder_request.content)
+        if resp_json.get('error', None):
+            message = resp_json['error']
+            messages.error(request, message)
+        else:
+            message = "Reminder scheduled!"
+            messages.success(request, message)
+        if add_num:
+            additional_request = requests.post('https://courtbot-python.herokuapp.com/api/reminders', {
+                "arraignment_datetime": arraignment_datetime,
+                "case_num": case_num,
+                "phone_num": f"+1-{add_num}"
+        })
+
+    return redirect('index')


### PR DESCRIPTION
Here is a possible solution for a reminder form that gathers case data and routes to the api endpoints.
- I wasn't sure how to get arraignment data from api/case with case# alone, so I added year and county inputs to the form
- JavaScript axios requests are always nice to prevent page reload, but since this is a python project I let the page reload with a django message displayed.
- Testing was a little tricky. To get tests to run without static file errors, I had to run 'manage.py collectstatic' before. I did delete the files afterward so I wasn't leaving anything in /staticfiles that wasn't there before. Also, successful 'Reminder scheduled' messages required actual case validation and arraignment data, so I used actual case data to test. I'm not sure if that's bad form or not, so I welcome any feedback.