### PR TITLE
Handling invalid year input (issue #23)

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -13,11 +13,18 @@ from alerts.models import Alert
 
 @csrf_exempt
 def case(request):
+    year_regex = re.compile(r'^[0-9]{4}$')
+    this_year = datetime.today().year
+    
     if request.method == 'GET':
         year = request.GET.get('year', 'NOT PROVIDED')
         county = request.GET.get('county', 'NOT PROVIDED')
         case_num = request.GET.get('case_num', 'NOT PROVIDED')
 
+        if not year_regex.match(year) or int(year) > this_year or int(year) < 1900:
+            err_msg = (
+                f'invalid year: {year}')
+            return JsonResponse({'error': err_msg})
         try:
             case = oscn.request.Case(year=year, county=county, number=case_num)
         except Exception as exc:


### PR DESCRIPTION
Fix for issue #23
The below is an example of the return.

![image](https://user-images.githubusercontent.com/44413241/95691769-40f3c300-0be7-11eb-8339-ec4489f071d5.png)

Also, I evaluate the range of year, but I am not sure if this evaluations are necessary or not.